### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -105,3 +105,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is currently signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,42 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Competitive basketball team for interscholastic games",
+        "schedule": "Mondays, Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["alex@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Tennis instruction and practice for all skill levels",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["sarah@mergington.edu", "james@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Explore painting, drawing, and mixed media techniques",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["isabella@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Perform in plays, musicals, and theatrical productions",
+        "schedule": "Thursdays, 3:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["lucas@mergington.edu", "ava@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore STEM topics",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": ["noah@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Participate in competitive debate competitions",
+        "schedule": "Tuesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["grace@mergington.edu", "tyler@mergington.edu"]
     }
 }
 
@@ -61,6 +97,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")  
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,16 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -12,6 +22,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,13 +30,47 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participants = details.participants || [];
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title">Participants</p>
+            <ul class="participants-list"></ul>
+          </div>
         `;
+
+        const participantsList = activityCard.querySelector(".participants-list");
+
+        if (participants.length) {
+          participants.forEach((participant) => {
+            const participantItem = document.createElement("li");
+            participantItem.className = "participant-item";
+
+            const participantText = document.createElement("span");
+            participantText.textContent = participant;
+
+            const deleteButton = document.createElement("button");
+            deleteButton.type = "button";
+            deleteButton.className = "participant-remove-btn";
+            deleteButton.dataset.activity = name;
+            deleteButton.dataset.email = participant;
+            deleteButton.setAttribute("aria-label", `Remove ${participant} from ${name}`);
+            deleteButton.innerHTML = "&#128465;";
+
+            participantItem.appendChild(participantText);
+            participantItem.appendChild(deleteButton);
+            participantsList.appendChild(participantItem);
+          });
+        } else {
+          const emptyState = document.createElement("li");
+          emptyState.className = "participants-empty";
+          emptyState.textContent = "No participants yet. Be the first to sign up!";
+          participantsList.appendChild(emptyState);
+        }
 
         activitiesList.appendChild(activityCard);
 
@@ -59,25 +104,51 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
+        await fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const removeButton = event.target.closest(".participant-remove-btn");
+
+    if (!removeButton) {
+      return;
+    }
+
+    const { activity, email } = removeButton.dataset;
+
+    if (!activity || !email) {
+      showMessage("Could not determine participant to remove.", "error");
+      return;
+    }
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(result.message, "success");
+        await fetchActivities();
+      } else {
+        showMessage(result.detail || "Unable to remove participant.", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to remove participant. Please try again.", "error");
+      console.error("Error removing participant:", error);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,70 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid #e3e8ff;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #f8faff 0%, #eef2ff 100%);
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  font-weight: bold;
+  color: #283593;
+}
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #1f2937;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+  padding: 8px 10px;
+  background-color: rgba(255, 255, 255, 0.9);
+  border: 1px solid #dbe4ff;
+  border-radius: 6px;
+}
+
+.participant-remove-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid #f5c2c7;
+  background-color: #fff5f5;
+  color: #c62828;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.participant-remove-btn:hover {
+  background-color: #ffe4e6;
+  color: #b91c1c;
+}
+
+.participant-remove-btn:focus-visible {
+  outline: 2px solid #b91c1c;
+  outline-offset: 1px;
+}
+
+.participants-list .participants-empty {
+  margin: 0;
+  color: #5f6368;
+  font-style: italic;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+
+BASE_ACTIVITIES = copy.deepcopy(app_module.activities)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    app_module.activities = copy.deepcopy(BASE_ACTIVITIES)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,23 @@
+def test_get_activities_returns_expected_shape(client):
+    # Arrange
+    endpoint = "/activities"
+
+    # Act
+    response = client.get(endpoint)
+    activities = response.json()
+
+    # Assert
+    assert response.status_code == 200
+    assert isinstance(activities, dict)
+    assert activities
+
+    for _, details in activities.items():
+        assert isinstance(details, dict)
+        assert "description" in details
+        assert "schedule" in details
+        assert "max_participants" in details
+        assert "participants" in details
+        assert isinstance(details["description"], str)
+        assert isinstance(details["schedule"], str)
+        assert isinstance(details["max_participants"], int)
+        assert isinstance(details["participants"], list)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,10 @@
+def test_root_redirects_to_static_index(client):
+    # Arrange
+    endpoint = "/"
+
+    # Act
+    response = client.get(endpoint, follow_redirects=False)
+
+    # Assert
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,47 @@
+from urllib.parse import quote
+
+import src.app as app_module
+
+
+def test_signup_adds_new_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+    endpoint = f"/activities/{quote(activity_name, safe='')}/signup"
+    assert email not in app_module.activities[activity_name]["participants"]
+
+    # Act
+    response = client.post(endpoint, params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Signed up {email} for {activity_name}"
+    assert email in app_module.activities[activity_name]["participants"]
+
+
+def test_signup_rejects_duplicate_participant(client):
+    # Arrange
+    activity_name = "Programming Class"
+    email = "emma@mergington.edu"
+    endpoint = f"/activities/{quote(activity_name, safe='')}/signup"
+
+    # Act
+    response = client.post(endpoint, params={"email": email})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Student already signed up for this activity"
+
+
+def test_signup_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "student@mergington.edu"
+    endpoint = f"/activities/{quote(activity_name, safe='')}/signup"
+
+    # Act
+    response = client.post(endpoint, params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,48 @@
+from urllib.parse import quote
+
+import src.app as app_module
+
+
+def test_unregister_removes_existing_participant(client):
+    # Arrange
+    activity_name = "Gym Class"
+    email = "john@mergington.edu"
+    endpoint = f"/activities/{quote(activity_name, safe='')}/signup"
+    assert email in app_module.activities[activity_name]["participants"]
+
+    # Act
+    response = client.delete(endpoint, params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json()["message"] == f"Unregistered {email} from {activity_name}"
+    assert email not in app_module.activities[activity_name]["participants"]
+
+
+def test_unregister_rejects_non_member(client):
+    # Arrange
+    activity_name = "Tennis Club"
+    email = "not.registered@mergington.edu"
+    endpoint = f"/activities/{quote(activity_name, safe='')}/signup"
+    assert email not in app_module.activities[activity_name]["participants"]
+
+    # Act
+    response = client.delete(endpoint, params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Student is not signed up for this activity"
+
+
+def test_unregister_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "student@mergington.edu"
+    endpoint = f"/activities/{quote(activity_name, safe='')}/signup"
+
+    # Act
+    response = client.delete(endpoint, params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Activity not found"


### PR DESCRIPTION
This pull request introduces several new features and improvements to the activity signup system, including the ability for users to view and remove participants from activities, enhanced frontend feedback, and comprehensive backend validation. Additionally, it adds thorough test coverage for both the signup and unregister flows, as well as for API responses and state management.

**Backend enhancements and API changes:**

* Added new activities (`Basketball Team`, `Tennis Club`, `Art Studio`, `Drama Club`, `Science Club`, `Debate Team`) to the `activities` data structure in `src/app.py`.
* Implemented backend validation to prevent duplicate signups and added a new `unregister_from_activity` endpoint to allow removing a participant from an activity in `src/app.py`.

**Frontend improvements:**

* Enhanced the UI in `src/static/app.js` and `src/static/styles.css` to display participants for each activity, allow removing participants via a button, and provide user feedback with timed messages. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R25-R74) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L62-R151) [[3]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R7-R16) [[4]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R140)

**Testing and reliability:**

* Added fixtures in `tests/conftest.py` to reset the activities state between tests, ensuring isolation and reliability.
* Added comprehensive tests for the signup and unregister endpoints, including edge cases such as duplicate signups, removing non-members, and handling unknown activities in `tests/test_signup.py` and `tests/test_unregister.py`. [[1]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R47) [[2]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R48)
* Added tests to verify the shape of the `/activities` API response and the root redirect behavior in `tests/test_activities.py` and `tests/test_root.py`. [[1]](diffhunk://#diff-1296adb14376e606bd4f15dbb75f86149ab573e22b6ad4987870b03bc16dbcf5R1-R23) [[2]](diffhunk://#diff-057c714a837425bada63f651bb83c04ebc1872ec1ff3733d815728bdf66cd1f9R1-R10)